### PR TITLE
Drop Twig 1 support, add twig3

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This extension was written by [Alain Tiemblo](https://github.com/ninsuo), (with 
 
 In this example, `menu` is an array of objects, each containing `name`, `url`, and `children` properties (`children` is itself an array of objects with the same properties, etc).
 
-```jinja
+```twig
 {% tree item in menu %}
   {% if treeloop.first %}<ul>{% endif %}
     <li>
@@ -37,7 +37,7 @@ In this example, `menu` is an array of objects, each containing `name`, `url`, a
 ```
 
 Just like a `{% for %}` loop, you can access the key of each list item:
-```jinja
+```twig
 {% tree key, item in menu %}
   <li>
     <b>Item {{ key }}</b>: {{ item.name }}

--- a/README.md
+++ b/README.md
@@ -88,6 +88,15 @@ To handle the edge case where you want to start a new tree inside another tree (
 composer require jordanlev/twig-tree-tag
 ```
 
+```yaml
+# services.yaml
+services:
+    twig.tree:
+      class: JordanLev\TwigTreeTag\Twig\Extension\TreeExtension
+      tags:
+        - { name: twig.extension }
+```
+
 ## Usage
 
 ```php

--- a/README.md
+++ b/README.md
@@ -9,9 +9,19 @@ Requires PHP 8.1 or higher
 
 ## Installation
 
-```sh
-composer config repositories.tacman_tree_tag_tag '{"type": "vcs", "url": "git@github.com:tacman/twig-tree-tag.git"}'
-composer require jordanlev/twig-tree-tag
+```bash
+composer require tacman/twig-tree-tag
+```
+
+Now register it in services.yaml
+
+```yaml
+# services.yaml
+services:
+    twig.tree:
+      class: JordanLev\TwigTreeTag\Twig\Extension\TreeExtension
+      tags:
+        - { name: twig.extension }
 ```
 
 ## Idea
@@ -72,7 +82,7 @@ Additionally, `treeloop` also contains 2 extra variables that tell you about the
 
 To handle the edge case where you want to start a new tree inside another tree (that is, a new tree "root" with its own markup), use `as` in your `{% tree %}` tag to assign each tree to a var name, then pass it into `subtree` via `with`. This allows Twig to know which `{% tree %}` should be called when it comes across the `{% subtree %}` tag. For example...
 
-```jinja
+```twig
 {% tree item in menu as treeA %}
   {% if treeloop.first %}<ul>{% endif %}
     <li>
@@ -90,29 +100,6 @@ To handle the edge case where you want to start a new tree inside another tree (
 {% endtree %}
 ```
 
-
-```yaml
-# services.yaml
-services:
-    twig.tree:
-      class: JordanLev\TwigTreeTag\Twig\Extension\TreeExtension
-      tags:
-        - { name: twig.extension }
-```
-
-## Usage
-
-```php
-$loader = require __DIR__.'/vendor/autoload.php';
-
-$twig = new \Twig_Environment(
-    new \Twig_Loader_Filesystem(__DIR__.'/view/')
-);
-
-$twig->addExtension(new JordanLev\TwigTreeTag\Twig\Extension\TreeExtension());
-
-// (...)
-```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # twig-tree-tag
 
-A Twig extension for succinctly traversing nested lists (e.g. navigation menus).  Based on https://github.com/jordanlev/twig-tree-tag, but updated to PHP 8 and Twig 3.
+A Twig extension for succinctly traversing nested lists (e.g. navigation menus).  Based on https://github.com/jordanlev/twig-tree-tag, adapted for PHP 8 and Twig 3 by Tac Tacelosky.
 
 ## Requirements
-
 
 Requires PHP 8.1 or higher
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # twig-tree-tag
 
-A Twig extension for succinctly traversing nested lists (e.g. navigation menus).
+A Twig extension for succinctly traversing nested lists (e.g. navigation menus).  Based on https://github.com/jordanlev/twig-tree-tag, but updated to PHP 8 and Twig 3.
 
 ## Requirements
 
 
-Requires PHP 7.4 or higher
+Requires PHP 8.1 or higher
 
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -4,7 +4,16 @@ A Twig extension for succinctly traversing nested lists (e.g. navigation menus).
 
 ## Requirements
 
-Requires PHP 5.4 or higher (due to usage of `$this` in anonymous function of compiled templates -- unfortunately this is the only way to achieve the desired recursion of a block calling itself).
+
+Requires PHP 7.4 or higher
+
+
+## Installation
+
+```sh
+composer config repositories.tacman_tree_tag_tag '{"type": "vcs", "url": "git@github.com:tacman/twig-tree-tag.git"}'
+composer require jordanlev/twig-tree-tag
+```
 
 ## Idea
 
@@ -82,11 +91,6 @@ To handle the edge case where you want to start a new tree inside another tree (
 {% endtree %}
 ```
 
-## Installation
-
-```sh
-composer require jordanlev/twig-tree-tag
-```
 
 ```yaml
 # services.yaml

--- a/composer.json
+++ b/composer.json
@@ -16,9 +16,12 @@
         }
     ],
     "require": {
-        "twig/twig": "^1.20"
+        "twig/twig": "^3.4"
     },
     "autoload": {
          "psr-4": {"JordanLev\\TwigTreeTag\\": "src"}
+    },
+    "require-dev": {
+        "phpstan/phpstan": "^1.6"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,9 @@
 {
-    "name": "jordanlev/twig-tree-tag",
+    "name": "tacman/twig-tree-tag",
     "type": "library",
-    "description": "A Twig extension for succinctly traversing nested lists (e.g. navigation menus).",
+    "description": "A Twig extension for succinctly traversing nested lists (e.g. navigation menus), supporting Twig 3",
     "keywords": [],
-    "homepage": "https://github.com/jordanlev/twig-tree-tag",
+    "homepage": "https://github.com/tacman/twig-tree-tag",
     "license": "MIT",
     "authors": [
         {
@@ -13,16 +13,24 @@
         {
             "name": "Jordan Lev",
             "email": "github@jordanlev.com"
+        },
+        {
+            "name": "Tac Tacelosky",
+            "email": "tacman@gmail.com"
         }
     ],
     "require": {
-        "php": ">= 7.4",
-        "twig/twig": "^2|^3"
+        "php": ">= 8.1",
+        "rector/rector": "^0.13.9",
+        "twig/twig": "^3"
+    },
+    "scripts": {
+        "phpstan": "vendor/bin/phpstan"
     },
     "autoload": {
          "psr-4": {"JordanLev\\TwigTreeTag\\": "src"}
     },
     "require-dev": {
-        "phpstan/phpstan": "^1.6"
+        "phpstan/phpstan": "^1.8.2"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
         }
     ],
     "require": {
-        "twig/twig": "^3.4"
+        "php": ">= 7.4",
+        "twig/twig": "^2|^3"
     },
     "autoload": {
          "psr-4": {"JordanLev\\TwigTreeTag\\": "src"}

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": ">= 8.1",
         "rector/rector": "^0.15",
-        "twig/twig": "^3"
+        "twig/twig": "^3|^4"
     },
     "scripts": {
         "phpstan": "vendor/bin/phpstan"

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "php": ">= 8.1",
-        "rector/rector": "^0.13.9",
+        "rector/rector": "^0.15",
         "twig/twig": "^3"
     },
     "scripts": {

--- a/demo/composer.json
+++ b/demo/composer.json
@@ -1,0 +1,21 @@
+{
+    "name": "tac/demo",
+    "description": "Tree Tag demo",
+    "type": "project",
+    "require": {
+        "twig/twig": "^2.0",
+        "qeep-pro/twig-tree-tag": "^2.0"
+    },
+    "license": "MIT",
+    "autoload": {
+        "psr-4": {
+            "Tac\\Demo\\": "src/"
+        }
+    },
+    "authors": [
+        {
+            "name": "Tac Tacelosky",
+            "email": "tacman@gmail.com"
+        }
+    ]
+}

--- a/demo/full_implementation.php
+++ b/demo/full_implementation.php
@@ -2,8 +2,8 @@
 
 $loader = require __DIR__.'/../vendor/autoload.php';
 
-$twig = new \Twig_Environment(
-    new \Twig_Loader_Filesystem(__DIR__)
+$twig = new \Twig\Environment(
+    new \Twig\Loader\FilesystemLoader(__DIR__)
 );
 
 $twig->addExtension(new JordanLev\TwigTreeTag\Twig\Extension\TreeExtension());

--- a/demo/index.php
+++ b/demo/index.php
@@ -1,0 +1,36 @@
+<?php
+
+$loader = require __DIR__.'/../vendor/autoload.php';
+
+$twig = new \Twig\Environment(
+    new \Twig\Loader\FilesystemLoader(__DIR__)
+);
+
+$twig->addExtension(new JordanLev\TwigTreeTag\Twig\Extension\TreeExtension());
+
+/*
+ * we are building an array representing a directory tree.
+ * - each key is a file or a directory name
+ * - each value is another array of the same format if the key is a directory
+ */
+
+$dir = __DIR__.'/../vendor/twig/twig/lib/Twig';
+
+function createTree($dir) {
+    $glob = glob($dir.'/*');
+    $nodes = array();
+    foreach ($glob as $path) {
+        if (is_dir($path)) {
+            $nodes[basename($path)] = createTree($path);
+        } else {
+            $nodes[basename($path)] = null;
+        }
+    }
+
+    return $nodes;
+}
+
+echo $twig->render('full_implementation.twig', array(
+    'files' => createTree($dir)
+));
+

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,5 @@
+parameters:
+    level: 5
+    inferPrivatePropertyTypeFromConstructor: true
+    paths:
+        - ./src/

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CodeQuality\Rector\Class_\InlineConstructorDefaultToPropertyRector;
+use Rector\Config\RectorConfig;
+use Rector\Doctrine\Set\DoctrineSetList;
+use Rector\Symfony\Set\SymfonySetList;
+use Rector\Symfony\Set\SensiolabsSetList;
+use Rector\Nette\Set\NetteSetList;
+use Rector\Set\ValueObject\LevelSetList;
+use Rector\CodeQuality\Rector\ClassMethod\ReturnTypeFromStrictScalarReturnExprRector;
+use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictBoolReturnExprRector;
+use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictNativeFuncCallRector;
+use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromStrictNewArrayRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->paths([
+        __DIR__ . '/src'
+    ]);
+
+    $rectorConfig->rules([
+        \Rector\Symfony\Rector\Class_\CommandPropertyToAttributeRector::class,
+        ReturnTypeFromStrictBoolReturnExprRector::class,
+        ReturnTypeFromStrictNewArrayRector::class,
+        ReturnTypeFromStrictScalarReturnExprRector::class,
+    ]);
+
+    $rectorConfig->rule(InlineConstructorDefaultToPropertyRector::class);
+    $rectorConfig->sets([
+        LevelSetList::UP_TO_PHP_81,
+        DoctrineSetList::ANNOTATIONS_TO_ATTRIBUTES,
+        SymfonySetList::SYMFONY_60,
+        SymfonySetList::ANNOTATIONS_TO_ATTRIBUTES,
+        NetteSetList::ANNOTATIONS_TO_ATTRIBUTES,
+        SensiolabsSetList::FRAMEWORK_EXTRA_61,
+    ]);
+};
+

--- a/rector.php
+++ b/rector.php
@@ -32,7 +32,6 @@ return static function (RectorConfig $rectorConfig): void {
         DoctrineSetList::ANNOTATIONS_TO_ATTRIBUTES,
         SymfonySetList::SYMFONY_60,
         SymfonySetList::ANNOTATIONS_TO_ATTRIBUTES,
-        NetteSetList::ANNOTATIONS_TO_ATTRIBUTES,
         SensiolabsSetList::FRAMEWORK_EXTRA_61,
     ]);
 };

--- a/src/Twig/Extension/TreeExtension.php
+++ b/src/Twig/Extension/TreeExtension.php
@@ -3,8 +3,11 @@
 namespace JordanLev\TwigTreeTag\Twig\Extension;
 
 use JordanLev\TwigTreeTag\Twig\TokenParser\TreeTokenParser;
+use Twig\Environment;
+use Twig\Extension\AbstractExtension;
+use Twig\Extension\ExtensionInterface;
 
-class TreeExtension extends \Twig_Extension
+class TreeExtension extends AbstractExtension implements ExtensionInterface
 {
     public function __construct()
     {
@@ -13,14 +16,18 @@ class TreeExtension extends \Twig_Extension
         }
     }
 
-    public function getTokenParsers()
+    public function getTokenParsers(): array
     {
         return array(
             new TreeTokenParser(),
         );
     }
 
-    public function getName() {
-        return 'tree';
+//    public function getName() {
+//        return 'tree';
+//    }
+    public function getOperators()
+    {
+        return [];
     }
 }

--- a/src/Twig/Extension/TreeExtension.php
+++ b/src/Twig/Extension/TreeExtension.php
@@ -26,7 +26,8 @@ class TreeExtension extends AbstractExtension implements ExtensionInterface
 //    public function getName() {
 //        return 'tree';
 //    }
-    public function getOperators()
+
+    public function getOperators(): array
     {
         return [];
     }

--- a/src/Twig/Extension/TreeExtension.php
+++ b/src/Twig/Extension/TreeExtension.php
@@ -18,9 +18,7 @@ class TreeExtension extends AbstractExtension implements ExtensionInterface
 
     public function getTokenParsers(): array
     {
-        return array(
-            new TreeTokenParser(),
-        );
+        return [new TreeTokenParser()];
     }
 
 //    public function getName() {

--- a/src/Twig/Node/TreeNode.php
+++ b/src/Twig/Node/TreeNode.php
@@ -36,6 +36,7 @@ class TreeNode extends Node
             ->write("\$context['_parent'][\$level] = \$context;\n")
             // per https://github.com/twigphp/Twig/issues/4110
 //            ->write("\$context['_seq'] = twig_ensure_traversable(\$data);\n")
+            ->write("\$context['_seq'] = CoreExtension::ensureTraversable(\$data);\n")
         ;
 
         // initializing treeloop variable

--- a/src/Twig/Node/TreeNode.php
+++ b/src/Twig/Node/TreeNode.php
@@ -11,14 +11,7 @@ class TreeNode extends Node
 {
     public function __construct(AssignNameExpression $keyTarget, AssignNameExpression $valueTarget, AbstractExpression $seq,  string $as, array $data, int $lineno, string $tag)
     {
-        parent::__construct(array(
-            'key_target'   => $keyTarget,
-            'value_target' => $valueTarget,
-            'seq'          => $seq,
-           ), array(
-            'data'         => $data,
-            'as'           => $as,
-           ), $lineno, $tag);
+        parent::__construct(['key_target'   => $keyTarget, 'value_target' => $valueTarget, 'seq'          => $seq], ['data'         => $data, 'as'           => $as], $lineno, $tag);
     }
 
     public function compile(Compiler $compiler)

--- a/src/Twig/Node/TreeNode.php
+++ b/src/Twig/Node/TreeNode.php
@@ -84,7 +84,9 @@ class TreeNode extends Node
                     $compiler
                         ->write("if (is_array(\$context['_seq']) || (is_object(\$context['_seq']) && \$context['_seq'] instanceof Traversable)) {\n")
                         ->indent()
-                        ->write("\$tree_")
+        //            ->write("\$tree_")
+                        // per https://github.com/twigphp/Twig/issues/4110
+                        ->write("yield from \$tree_")
                         ->raw($data['with'])
                         ->raw("(")
                         ->subcompile($data['child'])

--- a/src/Twig/Node/TreeNode.php
+++ b/src/Twig/Node/TreeNode.php
@@ -36,7 +36,9 @@ class TreeNode extends Node
             ->write("\$context['_parent'][\$level] = \$context;\n")
             // per https://github.com/twigphp/Twig/issues/4110
 //            ->write("\$context['_seq'] = twig_ensure_traversable(\$data);\n")
-            ->write("\$context['_seq'] = CoreExtension::ensureTraversable(\$data);\n")
+//            ->write("\$context['_seq'] = CoreExtension::ensureTraversable(\$data);\n")
+            ->write("\$context['_seq'] = is_iterable(\$data) ? \$data : [];\n")
+
         ;
 
         // initializing treeloop variable

--- a/src/Twig/Node/TreeNode.php
+++ b/src/Twig/Node/TreeNode.php
@@ -14,7 +14,7 @@ class TreeNode extends Node
         parent::__construct(['key_target'   => $keyTarget, 'value_target' => $valueTarget, 'seq'          => $seq], ['data'         => $data, 'as'           => $as], $lineno, $tag);
     }
 
-    public function compile(Compiler $compiler)
+    public function compile(Compiler $compiler): void
     {
         $compiler
             ->addDebugInfo($this)
@@ -35,8 +35,6 @@ class TreeNode extends Node
         $compiler
             ->write("\$context['_parent'][\$level] = \$context;\n")
             // per https://github.com/twigphp/Twig/issues/4110
-//            ->write("\$context['_seq'] = twig_ensure_traversable(\$data);\n")
-//            ->write("\$context['_seq'] = CoreExtension::ensureTraversable(\$data);\n")
             ->write("\$context['_seq'] = is_iterable(\$data) ? \$data : [];\n")
 
         ;

--- a/src/Twig/Node/TreeNode.php
+++ b/src/Twig/Node/TreeNode.php
@@ -34,7 +34,8 @@ class TreeNode extends Node
         // backuping local scope context
         $compiler
             ->write("\$context['_parent'][\$level] = \$context;\n")
-            ->write("\$context['_seq'] = twig_ensure_traversable(\$data);\n")
+            // per https://github.com/twigphp/Twig/issues/4110
+//            ->write("\$context['_seq'] = twig_ensure_traversable(\$data);\n")
         ;
 
         // initializing treeloop variable
@@ -131,7 +132,9 @@ class TreeNode extends Node
         $compiler
             ->outdent()
             ->write("};\n")
-            ->write("\$tree_")
+//            ->write("\$tree_")
+                // per https://github.com/twigphp/Twig/issues/4110
+            ->write("yield from \$tree_")
             ->raw($this->getAttribute('as'))
             ->raw("(")
             ->subcompile($this->getNode('seq'))

--- a/src/Twig/Node/TreeNode.php
+++ b/src/Twig/Node/TreeNode.php
@@ -9,7 +9,7 @@ use Twig\Node\Node;
 
 class TreeNode extends Node
 {
-    public function __construct(AssignNameExpression $keyTarget, AssignNameExpression $valueTarget, AbstractExpression $seq,  $as, array $data, $lineno, $tag)
+    public function __construct(AssignNameExpression $keyTarget, AssignNameExpression $valueTarget, AbstractExpression $seq,  string $as, array $data, int $lineno, string $tag)
     {
         parent::__construct(array(
             'key_target'   => $keyTarget,

--- a/src/Twig/Node/TreeNode.php
+++ b/src/Twig/Node/TreeNode.php
@@ -2,9 +2,14 @@
 
 namespace JordanLev\TwigTreeTag\Twig\Node;
 
-class TreeNode extends \Twig_Node
+use Twig\Compiler;
+use Twig\Node\Expression\AbstractExpression;
+use Twig\Node\Expression\AssignNameExpression;
+use Twig\Node\Node;
+
+class TreeNode extends Node
 {
-    public function __construct(\Twig_Node_Expression_AssignName $keyTarget, \Twig_Node_Expression_AssignName $valueTarget, \Twig_Node_Expression $seq,  $as, array $data, $lineno, $tag)
+    public function __construct(AssignNameExpression $keyTarget, AssignNameExpression $valueTarget, AbstractExpression $seq,  $as, array $data, $lineno, $tag)
     {
         parent::__construct(array(
             'key_target'   => $keyTarget,
@@ -16,7 +21,7 @@ class TreeNode extends \Twig_Node
            ), $lineno, $tag);
     }
 
-    public function compile(\Twig_Compiler $compiler)
+    public function compile(Compiler $compiler)
     {
         $compiler
             ->addDebugInfo($this)

--- a/src/Twig/TokenParser/TreeTokenParser.php
+++ b/src/Twig/TokenParser/TreeTokenParser.php
@@ -4,17 +4,19 @@ namespace JordanLev\TwigTreeTag\Twig\TokenParser;
 
 use JordanLev\TwigTreeTag\Twig\Node\TreeNode;
 use Twig\Node\Expression\AssignNameExpression;
+use Twig\TokenParser\AbstractTokenParser;
+use Twig\Node\Node;
 use Twig\Token;
 
-class TreeTokenParser extends \Twig\TokenParser\AbstractTokenParser
+class TreeTokenParser extends AbstractTokenParser
 {
     // {% tree
-    public function getTag()
+    public function getTag(): string
     {
         return 'tree';
     }
 
-    public function parse(Token $token)
+    public function parse(Token $token): Node
     {
         $lineno   = $token->getLine();
         $stream   = $this->parser->getStream();

--- a/src/Twig/TokenParser/TreeTokenParser.php
+++ b/src/Twig/TokenParser/TreeTokenParser.php
@@ -35,16 +35,11 @@ class TreeTokenParser extends AbstractTokenParser
         // %}
         $stream->expect(Token::BLOCK_END_TYPE);
 
-        $data = array();
+        $data = [];
         while (true) {
 
             // backing up tag content
-            $data[] = array(
-                'type' => 'body',
-                'node' => $this->parser->subparse(function(Token $token) {
-                    return $token->test(array('subtree', 'endtree'));
-                })
-            );
+            $data[] = ['type' => 'body', 'node' => $this->parser->subparse(fn(Token $token) => $token->test(['subtree', 'endtree']))];
 
             // {% subtree
             if ($stream->next()->getValue() == 'subtree') {
@@ -62,11 +57,7 @@ class TreeTokenParser extends AbstractTokenParser
                 $stream->expect(Token::BLOCK_END_TYPE);
 
                 // backing up subtree details
-                $data[] = array(
-                    'type'  => 'subtree',
-                    'with'  => $with,
-                    'child' => $child,
-                );
+                $data[] = ['type'  => 'subtree', 'with'  => $with, 'child' => $child];
 
             // {% endtree
             } else {
@@ -78,7 +69,7 @@ class TreeTokenParser extends AbstractTokenParser
         }
 
         // key, item
-        if (count($targets) > 1) {
+        if ((is_countable($targets) ? count($targets) : 0) > 1) {
             $keyTarget   = $targets->getNode(0);
             $keyTarget   = new AssignNameExpression($keyTarget->getAttribute('name'), $keyTarget->getTemplateLine());
             $valueTarget = $targets->getNode(1);


### PR DESCRIPTION
Twig 2 deprecated the way the base classes were called, this PR gets rid of the deprecation errors and makes this compatible with Twig 3.

If you want to continue to support twig 1, perhaps this should be a new version.

Also, this PR bumps the minimum PHP version to 7.4, as everything earlier is now at EOL.

Great library, BTW!